### PR TITLE
fix: write input handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## unreleased [2021-07-02]
+
+### Features
+
+1. [20](https://github.com/bonitoo-io/influxdb-client-r/pull/20): Add public method for coercion to line protocol.
+
+### Bug Fixes
+
+1. [20](https://github.com/bonitoo-io/influxdb-client-r/pull/20): Handle single data.frame as input to write().

--- a/R/influxdb_client.R
+++ b/R/influxdb_client.R
@@ -182,6 +182,10 @@ InfluxDBClient <- R6::R6Class(
                      fieldCols = c("_field"="_value"),
                      timeCol = "_time",
                      ...) {
+      # vectorize x if necessary
+      if (!is.vector(x)) {
+        x <- list(x)
+      }
       # validate parameters
       xIsCharacter <- all(lapply(x, class) == "character")
       xIsDataFrame <- all(lapply(x, class) == "data.frame")
@@ -445,11 +449,6 @@ InfluxDBClient <- R6::R6Class(
           stop("mixed named 'fieldCols' list not supported")
         }
         named <- TRUE
-      }
-
-      # vectorize x if necessary
-      if (!is.vector(x)) {
-        x <- list(x)
       }
 
       # for all data frames

--- a/R/influxdb_client.R
+++ b/R/influxdb_client.R
@@ -247,6 +247,23 @@ InfluxDBClient <- R6::R6Class(
         # handle errors
         private$.throwIfNot2xx(resp)
       }
+    },
+
+    #' @description Coerces data to InfluxDB line protocol.
+    #' \emph{For debugging and introspection purposes.
+    #' Parameters are the same as for }\code{write}\emph{ method}.
+    #' @return line protocol text
+    as.lp = function(x, precision = c("ns", "us", "ms", "s"),
+                     measurementCol = "_measurement",
+                     tagCols = NULL,
+                     fieldCols = c("_field"="_value"),
+                     timeCol = "_time") {
+      # vectorize x if necessary
+      if (!is.vector(x)) {
+        x <- list(x)
+      }
+      # call impl
+      private$.toLineProtocol(x, precision, measurementCol, tagCols, fieldCols, timeCol)
     }
   ),
   private = list(

--- a/man/InfluxDBClient.Rd
+++ b/man/InfluxDBClient.Rd
@@ -58,6 +58,7 @@ ready <- client$health()
 \item \href{#method-query}{\code{InfluxDBClient$query()}}
 \item \href{#method-ready}{\code{InfluxDBClient$ready()}}
 \item \href{#method-write}{\code{InfluxDBClient$write()}}
+\item \href{#method-as.lp}{\code{InfluxDBClient$as.lp()}}
 \item \href{#method-clone}{\code{InfluxDBClient$clone()}}
 }
 }
@@ -179,6 +180,28 @@ For all other cases, just use simple vector of column names (see Examples).}
 of \code{nanotime} or \code{POSIXct} type. Default is \code{"_time"}.}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-as.lp"></a>}}
+\if{latex}{\out{\hypertarget{method-as.lp}{}}}
+\subsection{Method \code{as.lp()}}{
+Coerces data to InfluxDB line protocol.
+\emph{For debugging and introspection purposes.
+Parameters are the same as for }\code{write}\emph{ method}.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{InfluxDBClient$as.lp(
+  x,
+  precision = c("ns", "us", "ms", "s"),
+  measurementCol = "_measurement",
+  tagCols = NULL,
+  fieldCols = c(`_field` = "_value"),
+  timeCol = "_time"
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+line protocol text
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/localhost-8086/api/v2/write-00506d-dfdd53-POST.R
+++ b/tests/testthat/localhost-8086/api/v2/write-00506d-dfdd53-POST.R
@@ -1,0 +1,17 @@
+structure(list(url = "http://localhost:8086/api/v2/write?org=bonitoo&bucket=no-bucket&precision=ns", 
+    status_code = 404L, headers = structure(list(`content-type` = "application/json; charset=utf-8", 
+        `x-platform-error-code` = "not found", date = "Fri, 02 Jul 2021 12:49:41 GMT", 
+        `content-length` = "63"), class = c("insensitive", "list"
+    )), all_headers = list(list(status = 404L, version = "HTTP/1.1", 
+        headers = structure(list(`content-type` = "application/json; charset=utf-8", 
+            `x-platform-error-code` = "not found", date = "Fri, 02 Jul 2021 12:49:41 GMT", 
+            `content-length` = "63"), class = c("insensitive", 
+        "list")))), cookies = structure(list(domain = logical(0), 
+        flag = logical(0), path = logical(0), secure = logical(0), 
+        expiration = structure(numeric(0), class = c("POSIXct", 
+        "POSIXt")), name = logical(0), value = logical(0)), row.names = integer(0), class = "data.frame"), 
+    content = charToRaw("{\"code\":\"not found\",\"message\":\"bucket \\\"no-bucket\\\" not found\"}"), 
+    date = structure(1625230181, class = c("POSIXct", "POSIXt"
+    ), tzone = "GMT"), times = c(redirect = 0, namelookup = 3.6e-05, 
+    connect = 3.7e-05, pretransfer = 0.000106, starttransfer = 0.00078, 
+    total = 0.000806)), class = "response")

--- a/tests/testthat/test-private.R
+++ b/tests/testthat/test-private.R
@@ -165,6 +165,18 @@ test_that("toLineProtocol / x is not data.frame", {
   expect_error(f(), "'x' must be data.frame", fixed = TRUE)
 })
 
+test_that("toLineProtocol / x is not data.frame", {
+  data <- 1
+  f <- function () {
+    .client$toLineProtocol(data, precision = 'ns',
+                           measurementCol = 'no-measurement',
+                           tagCols = c("region", "sensor_id"),
+                           fieldCols = c("altitude", "grounded", "temperature"),
+                           timeCol = '_time')
+  }
+  expect_error(f(), "'x' must be data.frame", fixed = TRUE)
+})
+
 test_that("toLineProtocol / x is not list of data.frame", {
   data <- list(data.frame(), "not a data.frame")
   f <- function () {

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -77,7 +77,12 @@ with_mock_api({
   })
 
   test_that("write / NULL bucket", {
-    data <- data.frame()
+    # change measurement value to avoid overwriting source
+    data <- lapply(.data,
+                   function(t) {
+                     t['_measurement'] <- replicate(5, 'w-airSensors')
+                     return(t)
+                   })
     f = function() {
       .client$write(data, bucket = NULL, precision = 'ns',
                     tagCols = c("region", "sensor_id"))
@@ -86,7 +91,13 @@ with_mock_api({
   })
 
   test_that("write / non-existent bucket", {
-    data <- data.frame()
+    # change measurement value to avoid overwriting source
+    data <- lapply(.data,
+                   function(t) {
+                     t['_measurement'] <- replicate(5, 'w-airSensors')
+                     return(t)
+                   })
+    # mock response: write-00506d-dfdd53-POST.R
     f = function() {
       .client$write(data, bucket = "no-bucket", precision = 'ns')
     }
@@ -108,7 +119,13 @@ with_mock_api({
   })
 
   test_that("write / retry / non-existent bucket", { # tests non-retryable error
-    data <- data.frame()
+    # change measurement value to avoid overwriting source
+    data <- lapply(.data,
+                   function(t) {
+                     t['_measurement'] <- replicate(5, 'w-airSensors')
+                     return(t)
+                   })
+    # mock response: write-00506d-dfdd53-POST.R
     retry.client <- InfluxDBClient$new(url = test.url, token = test.token, org = test.org,
                                        retryOptions = TRUE)
     f = function() {


### PR DESCRIPTION
This PR
- adds client's `as.lp` public method to provide access to `data.frame` -> line protocol serialization
- fixes handling of single `data.frame` input to `write()`