### PR TITLE
fix: POSIXct handling

### DIFF
--- a/R/influxdb_client.R
+++ b/R/influxdb_client.R
@@ -141,7 +141,7 @@ InfluxDBClient <- R6::R6Class(
               stop(sprintf("cannot coerce '%s' to '%s': column already exist",
                            srcCol, targetCol))
             }
-            df[targetCol] <- as.POSIXct(df[,srcCol])
+            df[targetCol] <- as.POSIXct(df[,srcCol], tz = "GMT")
             df
           })
         }
@@ -311,10 +311,10 @@ InfluxDBClient <- R6::R6Class(
 
     as.lp.timestamp = function(x, precision) {
       switch(
-        class(x),
+        class(x)[1],
         "nanotime"= { private$as.rfc3339nano.timestamp(x, precision = precision) },
         "POSIXct"= { private$as.POSIXct.timestamp(x, precision = precision) },
-        stop(paste("unsupported time column type:", class(x)))
+        stop(paste("unsupported time column type:", class(x)[1]))
       )
     },
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -239,3 +239,23 @@ with_mock_api({
     print(retry.delays) # printed for visual inspection :(
   })
 })
+
+test_that("write / invalid input type", {
+  f = function() {
+    .client$write(c(1,2,3,4,5), bucket = "my-bucket", batchSize = 0, precision = 'ns')
+  }
+  expect_error(f(), "'x' must be data.frame or character", fixed = TRUE)
+})
+
+test_that("write / invalid batch size", {
+  # change measurement value to avoid overwriting source
+  data <- lapply(.data,
+                 function(t) {
+                   t['_measurement'] <- replicate(5, 'w-airSensors')
+                   return(t)
+                 })
+  f = function() {
+    .client$write(data, bucket = "my-bucket", batchSize = 0, precision = 'ns')
+  }
+  expect_error(f(), "'batchSize' must be >= 1 or FALSE", fixed = TRUE)
+})


### PR DESCRIPTION
This PR fixes POSIXct cases:
- input Flux timestamp coercion to POSIXct column with UTC tz
- type check before serializing to line protocol

In addition, there are more tests included to increase ccov.
